### PR TITLE
Implement initial DoodleClone web app

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,16 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # DoodleClone
+
+A minimal Doodle-like polling app built with HTML, CSS and JavaScript. Data is stored in browser `localStorage` and can be deployed as a static site using GitHub Pages.
+
+## Development
+
+Open `index.html` in a browser to test locally. Creating a poll generates a shareable link with a unique identifier in the URL.
+
+## Deployment
+
+Push changes to the `main` branch. GitHub Actions will automatically deploy the contents of the repository to GitHub Pages.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DoodleClone</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="app">
+        <h1>DoodleClone</h1>
+        <section id="create-section">
+            <h2>Create Poll</h2>
+            <form id="create-form">
+                <label>
+                    Title:
+                    <input type="text" id="title" required>
+                </label>
+                <label>
+                    Description:
+                    <textarea id="description"></textarea>
+                </label>
+                <label>
+                    Proposed Dates (comma separated):
+                    <input type="text" id="options" placeholder="2024-01-01 10:00, 2024-01-02 15:00" required>
+                </label>
+                <button type="submit">Create</button>
+            </form>
+        </section>
+        <section id="poll-section" class="hidden">
+            <h2 id="poll-title"></h2>
+            <p id="poll-desc"></p>
+            <form id="vote-form">
+                <div id="options-container"></div>
+                <label>
+                    Your name:
+                    <input type="text" id="participant" required>
+                </label>
+                <button type="submit">Submit Vote</button>
+            </form>
+            <div id="summary" class="hidden"></div>
+            <button id="finalize" class="hidden">Finalize Poll</button>
+        </section>
+        <div id="share" class="hidden"></div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,133 @@
+(function() {
+    const STORAGE_KEY = 'doodle-polls';
+
+    function loadPolls() {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : {};
+    }
+
+    function savePolls(polls) {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(polls));
+    }
+
+    function generateId() {
+        return Math.random().toString(36).substring(2, 10);
+    }
+
+    function createPoll(title, description, options) {
+        const polls = loadPolls();
+        const id = generateId();
+        polls[id] = {
+            id,
+            title,
+            description,
+            options: options.map(o => ({ value: o, votes: {} })),
+            finalized: false,
+            finalChoice: null
+        };
+        savePolls(polls);
+        return id;
+    }
+
+    function getPoll(id) {
+        const polls = loadPolls();
+        return polls[id];
+    }
+
+    function savePoll(poll) {
+        const polls = loadPolls();
+        polls[poll.id] = poll;
+        savePolls(polls);
+    }
+
+    function renderPoll(poll) {
+        document.getElementById('poll-title').textContent = poll.title;
+        document.getElementById('poll-desc').textContent = poll.description;
+        const container = document.getElementById('options-container');
+        container.innerHTML = '';
+        poll.options.forEach((opt, i) => {
+            const label = document.createElement('label');
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.value = i;
+            label.appendChild(checkbox);
+            label.appendChild(document.createTextNode(' ' + opt.value));
+            container.appendChild(label);
+        });
+        document.getElementById('poll-section').classList.remove('hidden');
+    }
+
+    function renderSummary(poll) {
+        const summary = document.getElementById('summary');
+        summary.innerHTML = '<h3>Current votes</h3>';
+        poll.options.forEach(opt => {
+            const p = document.createElement('p');
+            p.textContent = `${opt.value}: ${Object.keys(opt.votes).length} votes`;
+            summary.appendChild(p);
+        });
+        summary.classList.remove('hidden');
+    }
+
+    function showShareLink(id) {
+        const share = document.getElementById('share');
+        share.innerHTML = `<p>Share this link: <a href="?poll=${id}">${location.href.split('?')[0]}?poll=${id}</a></p>`;
+        share.classList.remove('hidden');
+    }
+
+    document.getElementById('create-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        const title = document.getElementById('title').value.trim();
+        const desc = document.getElementById('description').value.trim();
+        const options = document.getElementById('options').value.split(',').map(o => o.trim()).filter(Boolean);
+        if (!title || options.length === 0) return;
+        const id = createPoll(title, desc, options);
+        history.replaceState({}, '', '?poll=' + id);
+        document.getElementById('create-section').classList.add('hidden');
+        const poll = getPoll(id);
+        renderPoll(poll);
+        showShareLink(id);
+    });
+
+    document.getElementById('vote-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        const pollId = new URLSearchParams(location.search).get('poll');
+        const poll = getPoll(pollId);
+        const name = document.getElementById('participant').value.trim();
+        if (!poll || !name) return;
+        const checked = Array.from(document.querySelectorAll('#options-container input:checked')).map(el => parseInt(el.value));
+        checked.forEach(idx => {
+            poll.options[idx].votes[name] = true;
+        });
+        savePoll(poll);
+        renderSummary(poll);
+    });
+
+    document.getElementById('finalize').addEventListener('click', function() {
+        const pollId = new URLSearchParams(location.search).get('poll');
+        const poll = getPoll(pollId);
+        if (!poll) return;
+        const best = poll.options.reduce((prev, curr) => Object.keys(curr.votes).length > Object.keys(prev.votes).length ? curr : prev);
+        poll.finalized = true;
+        poll.finalChoice = best.value;
+        savePoll(poll);
+        alert('Poll finalized at: ' + best.value);
+        renderSummary(poll);
+    });
+
+    function init() {
+        const params = new URLSearchParams(location.search);
+        const pollId = params.get('poll');
+        if (pollId) {
+            document.getElementById('create-section').classList.add('hidden');
+            const poll = getPoll(pollId);
+            if (poll) {
+                renderPoll(poll);
+                renderSummary(poll);
+                document.getElementById('finalize').classList.remove('hidden');
+                showShareLink(pollId);
+            }
+        }
+    }
+
+    init();
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,12 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+}
+.hidden {
+    display: none;
+}
+#options-container label {
+    display: block;
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- set up basic HTML, CSS and JS for creating and voting on polls
- store poll data in browser `localStorage`
- display share links and vote summary
- include GitHub Actions workflow for GitHub Pages deployment
- update README with usage and deployment instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68873d6e9a84832d8fd6ea693a9036c5