### PR TITLE
Update docs for Jekyll build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A minimal Doodle-like polling app built with HTML, CSS and JavaScript. Data is s
 
 Open `index.html` in a browser to test locally. Creating a poll generates a shareable link with a unique identifier in the URL.
 
+You can also run `jekyll build` to produce the `_site` directory and preview the site exactly as it will appear on GitHub Pages.
+
 ## Deployment
 
 Push changes to the `main` branch. GitHub Actions will automatically deploy the contents of the repository to GitHub Pages.


### PR DESCRIPTION
## Summary
- clarify local development steps
- mention `jekyll build` for GitHub Pages preview

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874c515d9c832dbf096ace5f265f79