### PR TITLE
Add mobile swipe navigation and larger tap targets

### DIFF
--- a/script.js
+++ b/script.js
@@ -441,6 +441,29 @@
                 document.getElementById('toggle-theme').click();
             }
         });
+
+        let startX = 0;
+        let startY = 0;
+        document.addEventListener('touchstart', e => {
+            if (!window.matchMedia('(max-width: 480px)').matches) return;
+            const t = e.changedTouches[0];
+            startX = t.clientX;
+            startY = t.clientY;
+        }, { passive: true });
+        document.addEventListener('touchend', e => {
+            if (!window.matchMedia('(max-width: 480px)').matches) return;
+            const t = e.changedTouches[0];
+            const dx = t.clientX - startX;
+            const dy = t.clientY - startY;
+            if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+                const section = document.getElementById('poll-section');
+                if (dx < 0) {
+                    section.classList.add('show-summary');
+                } else {
+                    section.classList.remove('show-summary');
+                }
+            }
+        }, { passive: true });
     }
 
     init();

--- a/style.css
+++ b/style.css
@@ -112,6 +112,8 @@ button:focus {
     button {
         padding: 16px;
         font-size: 1.2em;
+        min-width: 44px;
+        min-height: 44px;
     }
     input[type="checkbox"] {
         width: 1.4em;
@@ -129,5 +131,18 @@ button:focus {
         bottom: 10px;
         right: 10px;
         z-index: 1000;
+        padding: 20px 24px;
+        font-size: 1.4em;
+        border-radius: 8px;
+        min-width: 56px;
+        min-height: 56px;
     }
+}
+
+#poll-section.show-summary #vote-form {
+    display: none;
+}
+
+#poll-section.show-summary #summary {
+    display: block;
 }


### PR DESCRIPTION
## Summary
- expand tap target of the Add Option button on small screens
- ensure buttons meet minimum size recommendations
- allow swiping left/right on mobile to toggle poll summary

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887699a8868832d94abd80dd5b49864