### PR TITLE
Integrate Firebase storage

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,10 @@
+// Replace with your Firebase project configuration
+const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_AUTH_DOMAIN",
+    projectId: "YOUR_PROJECT_ID",
+};
+
+if (typeof firebase !== 'undefined') {
+    firebase.initializeApp(firebaseConfig);
+}

--- a/index.html
+++ b/index.html
@@ -80,6 +80,9 @@
         </section>
         <div id="share" class="hidden"></div>
     </div>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+    <script src="firebase-config.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Firebase library links to `index.html`
- create `firebase-config.js` for initializing Firebase
- store polls in Firestore if available, falling back to `localStorage`
- update event handlers and helper functions to async/await

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68876c36acf4832db0623c42097d853c