### PR TITLE
Implement poll management and auth

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,0 +1,12 @@
+import { formatDate, toIcsDate } from '../script.js';
+
+describe('script utilities', () => {
+  test('toIcsDate converts ISO to ICS format', () => {
+    expect(toIcsDate('2023-01-01T00:00:00Z')).toBe('20230101T000000Z');
+  });
+
+  test('formatDate returns string', () => {
+    const result = formatDate('2023-01-01T12:00:00Z', 'UTC');
+    expect(typeof result).toBe('string');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
     <div id="app">
         <h1>DoodleClone</h1>
         <button id="toggle-theme" aria-label="Toggle dark mode">🌙</button>
+        <button id="auth-btn">Sign in</button>
+        <button id="show-manage">My Polls</button>
         <div id="message" role="alert" aria-live="polite" class="hidden"></div>
         <section id="create-section">
             <h2>Create Poll</h2>
@@ -30,6 +32,7 @@
                     </div>
                 </div>
                 <button type="button" id="add-option" aria-label="Add option">Add Option</button>
+                <button type="button" id="next-week">Next Week</button>
                 <label>
                     <input type="checkbox" id="allow-multiple"> Allow multiple selections
                 </label>
@@ -53,6 +56,11 @@
                 </label>
                 <button type="submit">Create</button>
             </form>
+        </section>
+        <section id="manage-section" class="hidden">
+            <h2>My Polls</h2>
+            <div id="poll-list"></div>
+            <button type="button" id="back-to-create">Back</button>
         </section>
         <section id="poll-section" class="hidden">
             <h2 id="poll-title"></h2>
@@ -94,6 +102,7 @@
     </div>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-analytics-compat.js"></script>
     <script src="firebase-config.js"></script>
     <script type="module">

--- a/style.css
+++ b/style.css
@@ -150,3 +150,9 @@ button:focus {
 #comments div {
     margin-bottom: 5px;
 }
+
+#poll-list div {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- add Firebase auth UI and poll manager
- include Next Week button for quick date presets
- notify users when new comments arrive
- create a simple poll list section
- basic tests for script helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688795818fe0832da5b6cbb265d66d1a