### PR TITLE
Fix init when DOM ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,11 @@
     <script src="firebase-config.js"></script>
     <script type="module">
 import { init } from "./script.js";
-document.addEventListener("DOMContentLoaded", init);
+if (document.readyState !== 'loading') {
+    init();
+} else {
+    document.addEventListener("DOMContentLoaded", init);
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure app initializes if DOMContentLoaded fired before inline script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d045314c832db9d558b781153c78