### PR TITLE
Fix poll creation when storage is blocked

### DIFF
--- a/__tests__/polls.test.js
+++ b/__tests__/polls.test.js
@@ -1,4 +1,4 @@
-import { setDB, createPoll, getPoll, savePoll, deletePoll, generateId } from '../polls.js';
+import { setDB, createPoll, getPoll, savePoll, deletePoll, generateId, loadPolls } from '../polls.js';
 
 const fakeData = {};
 const fakeDb = {
@@ -40,6 +40,14 @@ describe('poll storage', () => {
     await deletePoll(id);
     const deleted = await getPoll(id);
     expect(deleted).toBeNull();
+  });
+
+  test('loadPolls handles storage errors', () => {
+    const orig = localStorage.getItem;
+    localStorage.getItem = () => { throw new Error('fail'); };
+    const polls = loadPolls();
+    expect(polls).toEqual({});
+    localStorage.getItem = orig;
   });
 });
 

--- a/polls.js
+++ b/polls.js
@@ -3,12 +3,23 @@ export let db = null;
 export function setDB(database) { db = database; }
 
 export function loadPolls() {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : {};
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : {};
+    } catch (e) {
+        console.error('Failed to load polls from storage', e);
+        return {};
+    }
 }
 
 export function savePolls(polls) {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(polls));
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(polls));
+        return true;
+    } catch (e) {
+        console.error('Failed to save polls to storage', e);
+        return false;
+    }
 }
 
 export function generateId() {

--- a/script.js
+++ b/script.js
@@ -436,7 +436,13 @@ function renderPollList() {
         const title = document.getElementById('title').value.trim();
         const desc = document.getElementById('description').value.trim();
         let options = Array.from(document.querySelectorAll('.option-input')).map(i => i.value).filter(Boolean);
-        options = options.map(v => new Date(v).toISOString());
+        try {
+            options = options.map(v => new Date(v).toISOString());
+        } catch (err) {
+            console.error('Invalid date value', err);
+            showMessage('One or more option dates are invalid.');
+            return;
+        }
         options = Array.from(new Set(options));
         const allowMultiple = document.getElementById('allow-multiple').checked;
         const deadlineInput = document.getElementById('deadline').value;
@@ -474,6 +480,10 @@ function renderPollList() {
         history.replaceState({}, '', '?poll=' + id);
         document.getElementById('create-section').classList.add('hidden');
         const poll = await getPoll(id);
+        if (!poll) {
+            showMessage('Unable to save poll. Your browser may be blocking local storage.');
+            return;
+        }
         renderPoll(poll);
         renderSummary(poll);
         renderComments(poll);


### PR DESCRIPTION
## Summary
- handle exceptions in `loadPolls` and `savePolls`
- validate option dates when creating a poll
- warn users if poll saving fails
- add unit test covering storage error handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d2710998832d97788cf2434fb182