### PR TITLE
Add in-page console logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,10 @@
             <button id="delete" aria-label="Delete poll" class="hidden">Delete Poll</button>
         </section>
         <div id="share" class="hidden"></div>
+        <div id="console-output" class="hidden">
+            <h2>Console Output</h2>
+            <pre id="console-log" aria-live="polite"></pre>
+        </div>
     </div>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,29 @@ let lastCommentTs = 0;
 let lastVoteCount = 0;
 let deferredPrompt = null;
 
+function captureConsole() {
+    const container = document.getElementById('console-log');
+    const wrapper = document.getElementById('console-output');
+    if (!container || !wrapper) return;
+    const origLog = console.log.bind(console);
+    const origErr = console.error.bind(console);
+    function append(type, args) {
+        const msg = Array.from(args).map(a => {
+            if (typeof a === 'object') {
+                try { return JSON.stringify(a); } catch { return String(a); }
+            }
+            return String(a);
+        }).join(' ');
+        const div = document.createElement('div');
+        if (type === 'error') div.classList.add('error');
+        div.textContent = msg;
+        container.appendChild(div);
+        wrapper.classList.remove('hidden');
+    }
+    console.log = (...args) => { origLog(...args); append('log', args); };
+    console.error = (...args) => { origErr(...args); append('error', args); };
+}
+
 function formatDate(value, tz) {
         try {
             return new Date(value).toLocaleString([], { timeZone: tz });
@@ -579,6 +602,7 @@ function renderPollList() {
     });
 
     async function init() {
+        captureConsole();
         const savedTheme = localStorage.getItem('theme') || 'system';
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("service-worker.js");

--- a/style.css
+++ b/style.css
@@ -182,3 +182,20 @@ button:focus {
     justify-content: space-between;
     margin-bottom: 5px;
 }
+
+#console-output {
+    background: #fafafa;
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-top: 15px;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+body.dark #console-output {
+    background: #444;
+    color: #eee;
+}
+#console-output .error {
+    color: red;
+}


### PR DESCRIPTION
## Summary
- show console output in a new section
- style the console output box
- capture console.log and console.error messages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d59765a4832dad11d57450043dfc