### PR TITLE
Add button to clear browser caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 This repository contains a very simple mockup for a hypothetical Doodle Clone.
 Open `index.html` in your browser to see the page.
+
+The page now includes a **Force reload** button that will attempt to clear any
+registered service worker caches and reload the page from the network. This can
+be useful if an old version is still being served from the browser's cache.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <h1>Welcome to Doodle Clone</h1>
   <p>This is a simple mockup page.</p>
   <button id="clickMe">Click me</button>
+  <button id="clearCache">Force reload</button>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,20 @@
 document.getElementById('clickMe').addEventListener('click', () => {
   alert('Button clicked!');
 });
+
+async function clearCacheAndReload() {
+  if ('caches' in window) {
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map(name => caches.delete(name)));
+  }
+  if ('serviceWorker' in navigator) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    for (const registration of registrations) {
+      await registration.unregister();
+    }
+  }
+  // Force reload from the network
+  window.location.reload(true);
+}
+
+document.getElementById('clearCache').addEventListener('click', clearCacheAndReload);


### PR DESCRIPTION
## Summary
- add a button to force reload the page
- add helper in `script.js` that clears service worker caches and reloads
- document cache clear feature in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68884f6c66ec832d883af9ae225ac0c9