### PR TITLE
Add transaction cost calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Open `index.html` in your browser to see the page.
 The page now includes a **Force reload** button that will attempt to clear any
 registered service worker caches and reload the page from the network. This can
 be useful if an old version is still being served from the browser's cache.
+
+## Transaction cost calculator
+
+The page also provides a small calculator for estimating transaction costs on
+different stock exchanges. Enter a trade amount, choose the exchange and click
+**Compute Cost**. The following fee percentages are applied:
+
+- New York: **0.1%**
+- London: **0.5%**
+- Tokyo: **0.2%**
+- Frankfurt: **0.15%**

--- a/index.html
+++ b/index.html
@@ -11,6 +11,21 @@
   <p>This is a simple mockup page.</p>
   <button id="clickMe">Click me</button>
   <button id="clearCache">Force reload</button>
+
+  <h2>Calculate Transaction Cost</h2>
+  <div id="tradeCalculator">
+    <label for="amount">Trade Amount:</label>
+    <input type="number" id="amount" />
+    <label for="exchange">Exchange:</label>
+    <select id="exchange">
+      <option value="ny">New York</option>
+      <option value="london">London</option>
+      <option value="tokyo">Tokyo</option>
+      <option value="frankfurt">Frankfurt</option>
+    </select>
+    <button id="calcCost">Compute Cost</button>
+    <p id="costOutput"></p>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,26 @@ document.getElementById('clickMe').addEventListener('click', () => {
   alert('Button clicked!');
 });
 
+const exchangeCosts = {
+  ny: 0.001,        // New York: 0.1%
+  london: 0.005,    // London: 0.5%
+  tokyo: 0.002,     // Tokyo: 0.2%
+  frankfurt: 0.0015 // Frankfurt: 0.15%
+};
+
+function calculateCost() {
+  const amount = parseFloat(document.getElementById('amount').value);
+  const exchange = document.getElementById('exchange').value;
+  if (isNaN(amount)) {
+    alert('Please enter a valid amount');
+    return;
+  }
+  const rate = exchangeCosts[exchange] || 0;
+  const cost = amount * rate;
+  document.getElementById('costOutput').textContent =
+    `Transaction cost: ${cost.toFixed(2)}`;
+}
+
 async function clearCacheAndReload() {
   if ('caches' in window) {
     const cacheNames = await caches.keys();
@@ -18,3 +38,4 @@ async function clearCacheAndReload() {
 }
 
 document.getElementById('clearCache').addEventListener('click', clearCacheAndReload);
+document.getElementById('calcCost').addEventListener('click', calculateCost);

--- a/style.css
+++ b/style.css
@@ -8,3 +8,13 @@ button {
   padding: 0.5rem 1rem;
   font-size: 1rem;
 }
+
+#tradeCalculator {
+  margin-top: 1rem;
+}
+
+#tradeCalculator label,
+#tradeCalculator select,
+#tradeCalculator input {
+  margin: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- implement a small transaction cost calculator
- allow choosing New York, London, Tokyo, or Frankfurt with different fee rates
- style the new UI
- document the new calculator

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68886a1dfa44832dbc23eec2ee450ef6