### PR TITLE
Add example portfolio display

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <p>This is a simple mockup page.</p>
   <button id="clickMe">Click me</button>
   <button id="clearCache">Force reload</button>
+  <h2>Portfolio Allocation</h2>
+  <div id="portfolio"></div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,60 @@ document.getElementById('clickMe').addEventListener('click', () => {
   alert('Button clicked!');
 });
 
+const portfolioData = [
+  { ticker: 'AMZN', weight: 7.0, amount: 105000 },
+  { ticker: 'AXP', weight: 7.0, amount: 105000 },
+  { ticker: 'C', weight: 5.25, amount: 78750 },
+  { ticker: 'GE', weight: 6.0, amount: 90000 },
+  { ticker: 'GOOG', weight: 7.7, amount: 115500 },
+  { ticker: 'GS', weight: 5.0, amount: 75000 },
+  { ticker: 'IAG.L', weight: 6.4, amount: 96000 },
+  { ticker: 'JPM', weight: 5.42, amount: 81300 },
+  { ticker: 'META', weight: 5.92, amount: 88800 },
+  { ticker: 'MSFT', weight: 7.29, amount: 109350 },
+  { ticker: 'NFLX', weight: 9.25, amount: 138750 },
+  { ticker: 'NVDA', weight: 3.09, amount: 46350 },
+  { ticker: 'PLTR', weight: 5.18, amount: 77700 },
+  { ticker: 'RR.L', weight: 6.28, amount: 94200 },
+  { ticker: 'SNOW', weight: 6.88, amount: 103200 },
+  { ticker: 'Cash', weight: 6.34, amount: 95100 }
+];
+
+function renderPortfolio() {
+  const container = document.getElementById('portfolio');
+  if (!container) return;
+
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const tbody = document.createElement('tbody');
+
+  const headerRow = document.createElement('tr');
+  ['Ticker', 'Weight (%)', 'Amount (DKK)'].forEach(text => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+
+  portfolioData.forEach(item => {
+    const tr = document.createElement('tr');
+    const tdTicker = document.createElement('td');
+    tdTicker.textContent = item.ticker;
+    const tdWeight = document.createElement('td');
+    tdWeight.textContent = item.weight.toFixed(2);
+    const tdAmount = document.createElement('td');
+    tdAmount.textContent = item.amount.toLocaleString();
+    tr.append(tdTicker, tdWeight, tdAmount);
+    tbody.appendChild(tr);
+  });
+
+  table.append(thead, tbody);
+  container.appendChild(table);
+}
+
+// Render the portfolio table when the page loads
+renderPortfolio();
+
 async function clearCacheAndReload() {
   if ('caches' in window) {
     const cacheNames = await caches.keys();

--- a/style.css
+++ b/style.css
@@ -8,3 +8,14 @@ button {
   padding: 0.5rem 1rem;
   font-size: 1rem;
 }
+
+table {
+  margin: 1rem auto;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid #ccc;
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- add portfolio allocation table to the page
- style the table
- render example portfolio data from earlier conversation

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6888696c800c832d9d387a28684cc0ce